### PR TITLE
Make issen-rs architechture independent

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ GPLv3
 
 ## prerequirements
 
-AVX2 and BMI2 enabled x86\_64 CPU (Intel: Haswell or later, AMD: Excavator or later)
+~~AVX2 and BMI2 enabled x86\_64 CPU (Intel: Haswell or later, AMD: Excavator or later)~~
+issen-rs is now portable! We have confirmed that it works on x86\_64 (AMD64) and AArch64.
 
 ## Setup
 

--- a/src/engine/bits.rs
+++ b/src/engine/bits.rs
@@ -34,6 +34,13 @@ pub fn flip_horizontal(mut x: u64) -> u64 {
     x
 }
 
+// delta swap: bit swapping with mask
+//    MSB F              0 LSB
+// x:    [ponmlkjihgfedcba]
+// mask: [0011000010000000]
+// delta swap with shift = 3
+// res:  [pokjlnmiegfhdcba]
+//          ^^ ^^ ^  ^
 pub fn delta_swap(x: u64, mask: u64, delta: isize) -> u64 {
     let tmp = mask & (x ^ (x << delta));
     x ^ tmp ^ (tmp >> delta)

--- a/src/engine/bits.rs
+++ b/src/engine/bits.rs
@@ -1,5 +1,20 @@
 use core::arch::x86_64::{_pdep_u64, _pext_u64};
 
+pub trait BitManip {
+    fn pext(&self, mask: Self) -> Self;
+    fn pdep(&self, mask: Self) -> Self;
+}
+
+impl BitManip for u64 {
+    fn pext(&self, mask: u64) -> u64 {
+        unsafe { _pext_u64(*self, mask) }
+    }
+
+    fn pdep(&self, mask: u64) -> u64 {
+        unsafe { _pdep_u64(*self, mask) }
+    }
+}
+
 pub fn popcnt(x: u64) -> i8 {
     x.count_ones() as i8
 }
@@ -41,15 +56,6 @@ pub fn mirror_under_8(mut x: u64) -> u64 {
     x = ((x >> 2) & 0x33) | ((x << 2) & 0xCC);
     x = ((x >> 1) & 0x55) | ((x << 1) & 0xAA);
     x
-}
-
-pub fn pext(x: u64, mask: u64) -> u64 {
-    unsafe { _pext_u64(x, mask) }
-}
-
-#[allow(dead_code)]
-pub fn pdep(x: u64, mask: u64) -> u64 {
-    unsafe { _pdep_u64(x, mask) }
 }
 
 pub const BASE3: [usize; 256] = {

--- a/src/engine/board.rs
+++ b/src/engine/board.rs
@@ -38,10 +38,7 @@ fn smart_upper_bit(x: u64x4) -> u64x4 {
     0x8000_0000_0000_0000u64 >> y
 }
 
-#[cfg(all(
-    target_feature = "avx2",
-    not(all(target_feature = "avx512cd", target_feature = "avx512vl"))
-))]
+#[cfg(not(all(target_feature = "avx512cd", target_feature = "avx512vl")))]
 fn smart_upper_bit(mut x: u64x4) -> u64x4 {
     x |= x >> u64x4::from_array([8, 1, 7, 9]);
     x |= x >> u64x4::from_array([16, 2, 14, 18]);

--- a/src/engine/board.rs
+++ b/src/engine/board.rs
@@ -35,7 +35,7 @@ pub const BOARD_SIZE: usize = 64;
 #[cfg(all(target_feature = "avx512cd", target_feature = "avx512vl"))]
 fn smart_upper_bit(x: u64x4) -> u64x4 {
     let y = x.leading_zeros();
-    0x8000_0000_0000_0000u64 >> y
+    Simd::splat(0x8000_0000_0000_0000u64) >> y
 }
 
 #[cfg(not(all(target_feature = "avx512cd", target_feature = "avx512vl")))]

--- a/src/engine/board.rs
+++ b/src/engine/board.rs
@@ -107,7 +107,7 @@ impl Board {
             0x0102040810204000u64,
             0x0040201008040201u64,
         ]);
-        let mut mask = mask1 >> Simd::splat((63 - pos) as u64);
+        let mut mask = mask1 >> ((63 - pos) as u64);
         let mut outflank = smart_upper_bit(!om & mask) & p;
         let mut flipped = ((Simd::splat(0) - outflank) << 1) & mask;
         let mask2 = Simd::from_array([
@@ -116,7 +116,7 @@ impl Board {
             0x0002040810204080u64,
             0x8040201008040200u64,
         ]);
-        mask = mask2 << Simd::splat(pos as u64);
+        mask = mask2 << (pos as u64);
         outflank = !((!om & mask) - Simd::splat(1)) & mask & p;
         flipped |= !(iszero(outflank) - outflank) & mask;
         flipped.reduce_or()

--- a/src/engine/board.rs
+++ b/src/engine/board.rs
@@ -335,10 +335,10 @@ impl Board {
         const MASKS: [u64; 4] = [MASK_TOP, MASK_BOTTOM, MASK_LEFT, MASK_RIGHT];
         let mut res = 0;
         for mask in &MASKS {
-            let me = pext(self.player, *mask) as usize;
-            let op = pext(self.opponent, *mask) as usize;
+            let me = self.player.pext(*mask) as usize;
+            let op = self.opponent.pext(*mask) as usize;
             let base3 = BASE3[me] + 2 * BASE3[op];
-            res |= pdep(STABLE[base3], *mask);
+            res |= STABLE[base3].pdep(*mask);
         }
         let filled = !self.empty();
         let mut filled_v = filled;

--- a/src/engine/board.rs
+++ b/src/engine/board.rs
@@ -493,6 +493,7 @@ impl BoardWithColor {
         }
     }
 
+    #[allow(dead_code)]
     pub fn pass(&self) -> Option<BoardWithColor> {
         Some(BoardWithColor {
             board: self.board.pass()?,

--- a/src/engine/board.rs
+++ b/src/engine/board.rs
@@ -4,7 +4,6 @@ use crate::engine::bits::*;
 use crate::engine::hand::*;
 use anyhow::Result;
 use clap::ArgMatches;
-//use core::arch::x86_64::*;
 use std::cmp::min;
 use std::fmt;
 use std::io::{BufWriter, Write};
@@ -269,8 +268,8 @@ impl Board {
         flip_r |= pre_r & (flip_r >> shift2);
         let mut res = flip_l << shift1;
         res |= flip_r >> shift1;
-        res &= Simd::splat(self.empty());
-        res.reduce_or()
+        let res = res.reduce_or();
+        res & self.empty()
     }
 
     #[cfg(not(target_feature = "avx2"))]

--- a/src/engine/board.rs
+++ b/src/engine/board.rs
@@ -4,10 +4,11 @@ use crate::engine::bits::*;
 use crate::engine::hand::*;
 use anyhow::Result;
 use clap::ArgMatches;
-use core::arch::x86_64::*;
+//use core::arch::x86_64::*;
 use std::cmp::min;
 use std::fmt;
 use std::io::{BufWriter, Write};
+use std::simd::prelude::*;
 use std::str::FromStr;
 use thiserror::Error;
 
@@ -33,21 +34,21 @@ pub struct PlayIterator {
 pub const BOARD_SIZE: usize = 64;
 
 #[cfg(all(target_feature = "avx512cd", target_feature = "avx512vl"))]
-unsafe fn smart_upper_bit(x: __m256i) -> __m256i {
-    let y = _mm256_lzcnt_epi64(x);
-    _mm256_srlv_epi64(_mm256_set1_epi64x(0x8000_0000_0000_0000u64 as i64), y)
+unsafe fn smart_upper_bit(x: u64x4) -> u64x4 {
+    let y = x.leading_zeros();
+    0x8000_0000_0000_0000u64 >> y
 }
 
 #[cfg(all(
     target_feature = "avx2",
     not(all(target_feature = "avx512cd", target_feature = "avx512vl"))
 ))]
-unsafe fn smart_upper_bit(mut x: __m256i) -> __m256i {
-    x = _mm256_or_si256(x, _mm256_srlv_epi64(x, _mm256_setr_epi64x(8, 1, 7, 9)));
-    x = _mm256_or_si256(x, _mm256_srlv_epi64(x, _mm256_setr_epi64x(16, 2, 14, 18)));
-    x = _mm256_or_si256(x, _mm256_srlv_epi64(x, _mm256_setr_epi64x(32, 4, 28, 36)));
-    let lowers = _mm256_srlv_epi64(x, _mm256_setr_epi64x(8, 1, 7, 9));
-    _mm256_andnot_si256(lowers, x)
+unsafe fn smart_upper_bit(mut x: u64x4) -> u64x4 {
+    x |= x >> u64x4::from_array([8, 1, 7, 9]);
+    x |= x >> u64x4::from_array([16, 2, 14, 18]);
+    x |= x >> u64x4::from_array([32, 4, 28, 36]);
+    let lowers = x >> Simd::from_array([8, 1, 7, 9]);
+    !lowers & x
 }
 
 const fn smart_upper_bit_scalar(mut x: u64, lane: usize) -> u64 {
@@ -59,27 +60,20 @@ const fn smart_upper_bit_scalar(mut x: u64, lane: usize) -> u64 {
 }
 
 #[allow(dead_code)]
-unsafe fn upper_bit(mut x: __m256i) -> __m256i {
-    x = _mm256_or_si256(x, _mm256_srli_epi64(x, 1));
-    x = _mm256_or_si256(x, _mm256_srli_epi64(x, 2));
-    x = _mm256_or_si256(x, _mm256_srli_epi64(x, 4));
-    x = _mm256_or_si256(x, _mm256_srli_epi64(x, 8));
-    x = _mm256_or_si256(x, _mm256_srli_epi64(x, 16));
-    x = _mm256_or_si256(x, _mm256_srli_epi64(x, 32));
-    let lowers = _mm256_srli_epi64(x, 1);
-    _mm256_andnot_si256(lowers, x)
+unsafe fn upper_bit(mut x: u64x4) -> u64x4 {
+    x |= x >> 1;
+    x |= x >> 2;
+    x |= x >> 4;
+    x |= x >> 8;
+    x |= x >> 16;
+    x |= x >> 32;
+    let lowers = x >> 1;
+    !lowers & x
 }
 
 #[cfg(target_feature = "avx2")]
-unsafe fn iszero(x: __m256i) -> __m256i {
-    let zero = _mm256_setzero_si256();
-    _mm256_cmpeq_epi64(x, zero)
-}
-
-#[cfg(target_feature = "avx2")]
-unsafe fn reduce_or(x: __m256i) -> u64 {
-    let xh = _mm_or_si128(_mm256_castsi256_si128(x), _mm256_extracti128_si256(x, 1));
-    (_mm_cvtsi128_si64(xh) | _mm_extract_epi64(xh, 1)) as u64
+unsafe fn iszero(x: u64x4) -> u64x4 {
+    x.simd_eq(Simd::splat(0u64)).to_int().cast()
 }
 
 impl Board {
@@ -99,43 +93,34 @@ impl Board {
 
     #[cfg(target_feature = "avx2")]
     unsafe fn flip_simd(&self, pos: usize) -> u64 {
-        let p = _mm256_set1_epi64x(self.player as i64);
-        let o = _mm256_set1_epi64x(self.opponent as i64);
-        let omask = _mm256_setr_epi64x(
-            0xFFFFFFFFFFFFFFFFu64 as i64,
-            0x7E7E7E7E7E7E7E7Eu64 as i64,
-            0x7E7E7E7E7E7E7E7Eu64 as i64,
-            0x7E7E7E7E7E7E7E7Eu64 as i64,
-        );
-        let om = _mm256_and_si256(o, omask);
-        let mask1 = _mm256_setr_epi64x(
-            0x0080808080808080u64 as i64,
-            0x7f00000000000000u64 as i64,
-            0x0102040810204000u64 as i64,
-            0x0040201008040201u64 as i64,
-        );
-        let mut mask = _mm256_srlv_epi64(mask1, _mm256_set1_epi64x((63 - pos) as i64));
-        let mut outflank = _mm256_and_si256(smart_upper_bit(_mm256_andnot_si256(om, mask)), p);
-        let mut flipped = _mm256_and_si256(
-            _mm256_slli_epi64(_mm256_sub_epi64(_mm256_setzero_si256(), outflank), 1),
-            mask,
-        );
-        let mask2 = _mm256_setr_epi64x(
-            0x0101010101010100u64 as i64,
-            0x00000000000000feu64 as i64,
-            0x0002040810204080u64 as i64,
-            0x8040201008040200u64 as i64,
-        );
-        mask = _mm256_sllv_epi64(mask2, _mm256_set1_epi64x(pos as i64));
-        outflank = _mm256_andnot_si256(
-            _mm256_sub_epi64(_mm256_andnot_si256(om, mask), _mm256_set1_epi64x(1)),
-            _mm256_and_si256(mask, p),
-        );
-        flipped = _mm256_or_si256(
-            flipped,
-            _mm256_andnot_si256(_mm256_sub_epi64(iszero(outflank), outflank), mask),
-        );
-        reduce_or(flipped)
+        let p = Simd::splat(self.player);
+        let o = Simd::splat(self.opponent);
+        let omask = Simd::from_array([
+            0xFFFFFFFFFFFFFFFFu64,
+            0x7E7E7E7E7E7E7E7Eu64,
+            0x7E7E7E7E7E7E7E7Eu64,
+            0x7E7E7E7E7E7E7E7Eu64,
+        ]);
+        let om = o & omask;
+        let mask1 = Simd::from_array([
+            0x0080808080808080u64,
+            0x7f00000000000000u64,
+            0x0102040810204000u64,
+            0x0040201008040201u64,
+        ]);
+        let mut mask = mask1 >> Simd::splat((63 - pos) as u64);
+        let mut outflank = smart_upper_bit(!om & mask) & p;
+        let mut flipped = ((Simd::splat(0) - outflank) << 1) & mask;
+        let mask2 = Simd::from_array([
+            0x0101010101010100u64,
+            0x00000000000000feu64,
+            0x0002040810204080u64,
+            0x8040201008040200u64,
+        ]);
+        mask = mask2 << Simd::splat(pos as u64);
+        outflank = !((!om & mask) - Simd::splat(1)) & mask & p;
+        flipped |= !(iszero(outflank) - outflank) & mask;
+        flipped.reduce_or()
     }
 
     pub const fn flip_scalar(&self, pos: usize) -> u64 {
@@ -262,48 +247,30 @@ impl Board {
 
     #[cfg(target_feature = "avx2")]
     unsafe fn mobility_bits_simd(&self) -> u64 {
-        let shift1 = _mm256_setr_epi64x(1, 7, 9, 8);
-        let mask = _mm256_setr_epi64x(
-            0x7e7e7e7e7e7e7e7eu64 as i64,
-            0x7e7e7e7e7e7e7e7eu64 as i64,
-            0x7e7e7e7e7e7e7e7eu64 as i64,
-            0xffffffffffffffffu64 as i64,
-        );
-        let v_player = _mm256_set1_epi64x(self.player as i64);
-        let masked_op = _mm256_and_si256(_mm256_set1_epi64x(self.opponent as i64), mask);
-        let mut flip_l = _mm256_and_si256(masked_op, _mm256_sllv_epi64(v_player, shift1));
-        let mut flip_r = _mm256_and_si256(masked_op, _mm256_srlv_epi64(v_player, shift1));
-        flip_l = _mm256_or_si256(
-            flip_l,
-            _mm256_and_si256(masked_op, _mm256_sllv_epi64(flip_l, shift1)),
-        );
-        flip_r = _mm256_or_si256(
-            flip_r,
-            _mm256_and_si256(masked_op, _mm256_srlv_epi64(flip_r, shift1)),
-        );
-        let pre_l = _mm256_and_si256(masked_op, _mm256_sllv_epi64(masked_op, shift1));
-        let pre_r = _mm256_srlv_epi64(pre_l, shift1);
-        let shift2 = _mm256_add_epi64(shift1, shift1);
-        flip_l = _mm256_or_si256(
-            flip_l,
-            _mm256_and_si256(pre_l, _mm256_sllv_epi64(flip_l, shift2)),
-        );
-        flip_r = _mm256_or_si256(
-            flip_r,
-            _mm256_and_si256(pre_r, _mm256_srlv_epi64(flip_r, shift2)),
-        );
-        flip_l = _mm256_or_si256(
-            flip_l,
-            _mm256_and_si256(pre_l, _mm256_sllv_epi64(flip_l, shift2)),
-        );
-        flip_r = _mm256_or_si256(
-            flip_r,
-            _mm256_and_si256(pre_r, _mm256_srlv_epi64(flip_r, shift2)),
-        );
-        let mut res = _mm256_sllv_epi64(flip_l, shift1);
-        res = _mm256_or_si256(res, _mm256_srlv_epi64(flip_r, shift1));
-        res = _mm256_and_si256(res, _mm256_set1_epi64x(self.empty() as i64));
-        reduce_or(res)
+        let shift1 = Simd::from_array([1, 7, 9, 8]);
+        let mask = Simd::from_array([
+            0x7e7e7e7e7e7e7e7eu64,
+            0x7e7e7e7e7e7e7e7eu64,
+            0x7e7e7e7e7e7e7e7eu64,
+            0xffffffffffffffffu64,
+        ]);
+        let v_player = Simd::splat(self.player);
+        let masked_op = Simd::splat(self.opponent) & mask;
+        let mut flip_l = masked_op & (v_player << shift1);
+        let mut flip_r = masked_op & (v_player >> shift1);
+        flip_l |= masked_op & (flip_l << shift1);
+        flip_r |= masked_op & (flip_r >> shift1);
+        let pre_l = masked_op & (masked_op << shift1);
+        let pre_r = pre_l >> shift1;
+        let shift2 = shift1 + shift1;
+        flip_l |= pre_l & (flip_l << shift2);
+        flip_r |= pre_r & (flip_r >> shift2);
+        flip_l |= pre_l & (flip_l << shift2);
+        flip_r |= pre_r & (flip_r >> shift2);
+        let mut res = flip_l << shift1;
+        res |= flip_r >> shift1;
+        res &= Simd::splat(self.empty());
+        res.reduce_or()
     }
 
     #[cfg(not(target_feature = "avx2"))]

--- a/src/engine/board/test.rs
+++ b/src/engine/board/test.rs
@@ -248,13 +248,13 @@ fn iszero_naive(x: [u64; 4]) -> [u64; 4] {
     res
 }
 
-unsafe fn upper_bit_wrapper(x: [u64; 4]) -> [u64; 4] {
+fn upper_bit_wrapper(x: [u64; 4]) -> [u64; 4] {
     let x = Simd::from_array(x);
     let y = upper_bit(x);
     y.to_array()
 }
 
-unsafe fn iszero_wrapper(x: [u64; 4]) -> [u64; 4] {
+fn iszero_wrapper(x: [u64; 4]) -> [u64; 4] {
     let x = Simd::from_array(x);
     let y = iszero(x);
     y.to_array()
@@ -279,7 +279,7 @@ fn test_upper_bit() {
     for i in 0..(LENGTH / 4) {
         let a = &ary[(4 * i)..(4 * i + 4)];
         assert_eq!(
-            unsafe { upper_bit_wrapper(a.try_into().unwrap()) },
+            upper_bit_wrapper(a.try_into().unwrap()),
             upper_bit_naive(a.try_into().unwrap())
         );
     }
@@ -298,7 +298,7 @@ fn test_iszero() {
     for i in 0..=(LENGTH - 4) {
         let a = &ary[i..(i + 4)];
         assert_eq!(
-            unsafe { iszero_wrapper(a.try_into().unwrap()) },
+            iszero_wrapper(a.try_into().unwrap()),
             iszero_naive(a.try_into().unwrap())
         );
     }

--- a/src/engine/board/test.rs
+++ b/src/engine/board/test.rs
@@ -249,19 +249,15 @@ fn iszero_naive(x: [u64; 4]) -> [u64; 4] {
 }
 
 unsafe fn upper_bit_wrapper(x: [u64; 4]) -> [u64; 4] {
-    let x = _mm256_loadu_si256(&x as *const u64 as *const __m256i);
+    let x = Simd::from_array(x);
     let y = upper_bit(x);
-    let mut z = [0; 4];
-    _mm256_storeu_si256(&mut z as *mut u64 as *mut __m256i, y);
-    z
+    y.to_array()
 }
 
 unsafe fn iszero_wrapper(x: [u64; 4]) -> [u64; 4] {
-    let x = _mm256_loadu_si256(&x as *const u64 as *const __m256i);
+    let x = Simd::from_array(x);
     let y = iszero(x);
-    let mut z = [0; 4];
-    _mm256_storeu_si256(&mut z as *mut u64 as *mut __m256i, y);
-    z
+    y.to_array()
 }
 
 #[test]

--- a/src/engine/endgame.rs
+++ b/src/engine/endgame.rs
@@ -6,7 +6,6 @@ use crate::engine::hand::*;
 use crate::engine::search::*;
 use crate::engine::table::*;
 use arrayvec::ArrayVec;
-use core::arch::x86_64::_tzcnt_u64;
 use std::cmp::max;
 
 fn near_leaf(solve_obj: &mut SolveObj, board: Board) -> (i8, SolveStat) {
@@ -59,7 +58,7 @@ fn static_order(solve_obj: &mut SolveObj, board: Board, (mut alpha, beta): (i8, 
     for mask in MASKS.iter() {
         let mut remain = mobility_bits & mask;
         while remain != 0 {
-            let pos = unsafe { _tzcnt_u64(remain) } as usize;
+            let pos = remain.trailing_zeros() as usize;
             remain = remain & (remain - 1);
             if let Some(next) = board.play(pos) {
                 pass = false;

--- a/src/engine/eval.rs
+++ b/src/engine/eval.rs
@@ -141,6 +141,7 @@ impl Parameters {
             pattern_weights.extend(ex_weights);
             patterns.push(pattern);
         }
+        pattern_weights.push(0);
         while offsets.len() % 16 != 0 {
             offsets.push(offset as u32);
         }

--- a/src/engine/eval.rs
+++ b/src/engine/eval.rs
@@ -65,10 +65,10 @@ impl Parameters {
         let mut indices = vec![Vec::new(); 8];
         for i in 0..table_size {
             let mut t_pattern = pattern;
-            let mut t_bits = pdep(i as u64, t_pattern);
+            let mut t_bits = (i as u64).pdep(t_pattern);
             for dir in 0..4 {
-                indices[dir * 2].push(pext(t_bits, t_pattern) as usize);
-                indices[dir * 2 + 1].push(pext(flip_diag(t_bits), flip_diag(t_pattern)) as usize);
+                indices[dir * 2].push(t_bits.pext(t_pattern) as usize);
+                indices[dir * 2 + 1].push(flip_diag(t_bits).pext(flip_diag(t_pattern)) as usize);
                 t_bits = rot90(t_bits);
                 t_pattern = rot90(t_pattern);
             }
@@ -229,7 +229,7 @@ impl Evaluator {
             for row_bits in 0..256 {
                 let bits = row_bits << (row * 8);
                 for &pattern in patterns {
-                    let index = b3conv[pext(bits, pattern) as usize];
+                    let index = b3conv[bits.pext(pattern) as usize];
                     result.push(index as u16);
                 }
                 while result.len() % 16 != 0 {

--- a/src/engine/last_cache.rs
+++ b/src/engine/last_cache.rs
@@ -72,13 +72,13 @@ impl LastCache {
         let &(col_mask, diag1_mask, diag2_mask) = self.masks.get_unchecked(pos);
         let &(diag1_idx, diag2_idx) = self.indices.get_unchecked(pos);
         let &row_score = self.table.get_unchecked((row_bits as usize) * 8 + col);
-        let col_bits = pext(board.player, col_mask);
+        let col_bits = board.player.pext(col_mask);
         let &col_score = self.table.get_unchecked((col_bits as usize) * 8 + row);
-        let diag1_bits = pext(board.player, diag1_mask);
+        let diag1_bits = board.player.pext(diag1_mask);
         let &diag1_score = self
             .table
             .get_unchecked((diag1_bits as usize) * 8 + diag1_idx as usize);
-        let diag2_bits = pext(board.player, diag2_mask);
+        let diag2_bits = board.player.pext(diag2_mask);
         let &diag2_score = self
             .table
             .get_unchecked((diag2_bits as usize) * 8 + diag2_idx as usize);
@@ -88,11 +88,11 @@ impl LastCache {
         if diff_first > 0 {
             (pcnt - ocnt + 2 * diff_first + 1, 1)
         } else {
-            let diag1_bits_second = pext(board.opponent, diag1_mask);
+            let diag1_bits_second = board.opponent.pext(diag1_mask);
             let &diag1_score_second = self
                 .table
                 .get_unchecked((diag1_bits_second as usize) * 8 + diag1_idx as usize);
-            let diag2_bits_second = pext(board.opponent, diag2_mask);
+            let diag2_bits_second = board.opponent.pext(diag2_mask);
             let &diag2_score_second = self
                 .table
                 .get_unchecked((diag2_bits_second as usize) * 8 + diag2_idx as usize);

--- a/src/engine/last_cache.rs
+++ b/src/engine/last_cache.rs
@@ -2,7 +2,6 @@
 mod test;
 use crate::engine::bits::*;
 use crate::engine::board::*;
-use core::arch::x86_64::_tzcnt_u64;
 
 pub struct LastCache {
     table: [(i8, i8); 4096],
@@ -65,7 +64,7 @@ impl LastCache {
     }
 
     unsafe fn solve_last_impl(&self, board: Board) -> (i8, usize) {
-        let pos = _tzcnt_u64(board.empty()) as usize;
+        let pos = board.empty().trailing_zeros() as usize;
         let row = pos >> 3;
         let col = pos & 0b111;
         let row_bits = (board.player >> (row * 8)) & 0xff;

--- a/src/engine/last_cache.rs
+++ b/src/engine/last_cache.rs
@@ -63,6 +63,7 @@ impl LastCache {
         }
     }
 
+    #[cfg(target_feature = "bmi2")]
     fn solve_last_impl(&self, board: Board) -> (i8, usize) {
         unsafe {
             let pos = board.empty().trailing_zeros() as usize;
@@ -79,6 +80,80 @@ impl LastCache {
                 .table
                 .get_unchecked((diag1_bits as usize) * 8 + diag1_idx as usize);
             let diag2_bits = board.player.pext(diag2_mask);
+            let &diag2_score = self
+                .table
+                .get_unchecked((diag2_bits as usize) * 8 + diag2_idx as usize);
+            let pcnt = popcnt(board.player);
+            let ocnt = 63 - pcnt;
+            let diff_first = row_score.0 + col_score.0 + diag1_score.0 + diag2_score.0;
+            if diff_first > 0 {
+                (pcnt - ocnt + 2 * diff_first + 1, 1)
+            } else {
+                let diag1_bits_second = board.opponent.pext(diag1_mask);
+                let &diag1_score_second = self
+                    .table
+                    .get_unchecked((diag1_bits_second as usize) * 8 + diag1_idx as usize);
+                let diag2_bits_second = board.opponent.pext(diag2_mask);
+                let &diag2_score_second = self
+                    .table
+                    .get_unchecked((diag2_bits_second as usize) * 8 + diag2_idx as usize);
+                let diff_second = row_score.1 + col_score.1 + diag1_score_second.0 + diag2_score_second.0;
+                if diff_second > 0 {
+                    (pcnt - ocnt - 2 * diff_second - 1, 2)
+                } else if pcnt > ocnt {
+                    (64 - 2 * ocnt, 0)
+                } else {
+                    (2 * pcnt - 64, 0)
+                }
+            }
+        }
+    }
+
+    #[cfg(not(target_feature = "bmi2"))]
+    fn solve_last_impl(&self, board: Board) -> (i8, usize) {
+        fn get_col_bits(bits: u64, col: usize) -> u64 {
+            ((bits >> col).wrapping_mul(0x0002_0408_1020_4081) >> 49) & 0xff
+        }
+
+        fn get_diag1_bits(mut bits: u64, row: usize, col: usize) -> u64 {
+            let width = if row >= col {
+                bits = bits >> (8 * (row - col));
+                8 - (row - col)
+            } else {
+                bits = bits >> (col - row);
+                8 - (col - row)
+            };
+            (bits.wrapping_mul(0x0101_0101_0101_0101) >> 56) & ((1 << width) - 1)
+        }
+
+        fn get_diag2_bits(mut bits: u64, row: usize, col: usize) -> u64 {
+            let width = if row + col >= 7 {
+                bits = bits >> (8 * (row + col - 7));
+                15 - (row + col)
+            } else {
+                bits = bits << (7 - row - col);
+                row + col + 1
+            };
+            bits |= (bits >> 56) << 63;
+            bits = bits.wrapping_mul(0x7f) & 0x8080_8080_8080_8080;
+            (bits.wrapping_mul(0x0002_0408_1020_4081) >> 56) & ((1 << width) - 1)
+        }
+
+        unsafe {
+            let pos = board.empty().trailing_zeros() as usize;
+            let row = pos >> 3;
+            let col = pos & 0b111;
+            let row_bits = (board.player >> (row * 8)) & 0xff;
+            let &(col_mask, diag1_mask, diag2_mask) = self.masks.get_unchecked(pos);
+            let &(diag1_idx, diag2_idx) = self.indices.get_unchecked(pos);
+            let &row_score = self.table.get_unchecked((row_bits as usize) * 8 + col);
+            let col_bits = Self::get_col_bits(board.player & col_mask, col);
+            let &col_score = self.table.get_unchecked((col_bits as usize) * 8 + row);
+            let diag1_bits = Self::get_diag1_bits(board.player & diag1_mask, row, col);
+            let &diag1_score = self
+                .table
+                .get_unchecked((diag1_bits as usize) * 8 + diag1_idx as usize);
+            let diag2_bits = Self::get_diag2_bits(board.player & diag2_mask, row, col);
             let &diag2_score = self
                 .table
                 .get_unchecked((diag2_bits as usize) * 8 + diag2_idx as usize);

--- a/src/engine/last_cache.rs
+++ b/src/engine/last_cache.rs
@@ -64,81 +64,55 @@ impl LastCache {
     }
 
     #[cfg(target_feature = "bmi2")]
-    fn solve_last_impl(&self, board: Board) -> (i8, usize) {
-        unsafe {
-            let pos = board.empty().trailing_zeros() as usize;
-            let row = pos >> 3;
-            let col = pos & 0b111;
-            let row_bits = (board.player >> (row * 8)) & 0xff;
-            let &(col_mask, diag1_mask, diag2_mask) = self.masks.get_unchecked(pos);
-            let &(diag1_idx, diag2_idx) = self.indices.get_unchecked(pos);
-            let &row_score = self.table.get_unchecked((row_bits as usize) * 8 + col);
-            let col_bits = board.player.pext(col_mask);
-            let &col_score = self.table.get_unchecked((col_bits as usize) * 8 + row);
-            let diag1_bits = board.player.pext(diag1_mask);
-            let &diag1_score = self
-                .table
-                .get_unchecked((diag1_bits as usize) * 8 + diag1_idx as usize);
-            let diag2_bits = board.player.pext(diag2_mask);
-            let &diag2_score = self
-                .table
-                .get_unchecked((diag2_bits as usize) * 8 + diag2_idx as usize);
-            let pcnt = popcnt(board.player);
-            let ocnt = 63 - pcnt;
-            let diff_first = row_score.0 + col_score.0 + diag1_score.0 + diag2_score.0;
-            if diff_first > 0 {
-                (pcnt - ocnt + 2 * diff_first + 1, 1)
-            } else {
-                let diag1_bits_second = board.opponent.pext(diag1_mask);
-                let &diag1_score_second = self
-                    .table
-                    .get_unchecked((diag1_bits_second as usize) * 8 + diag1_idx as usize);
-                let diag2_bits_second = board.opponent.pext(diag2_mask);
-                let &diag2_score_second = self
-                    .table
-                    .get_unchecked((diag2_bits_second as usize) * 8 + diag2_idx as usize);
-                let diff_second = row_score.1 + col_score.1 + diag1_score_second.0 + diag2_score_second.0;
-                if diff_second > 0 {
-                    (pcnt - ocnt - 2 * diff_second - 1, 2)
-                } else if pcnt > ocnt {
-                    (64 - 2 * ocnt, 0)
-                } else {
-                    (2 * pcnt - 64, 0)
-                }
-            }
-        }
+    fn get_col_bits(bits: u64, mask: u64, _col: usize) -> u64 {
+        bits.pext(mask)
     }
 
     #[cfg(not(target_feature = "bmi2"))]
+    fn get_col_bits(mut bits: u64, mask: u64, col: usize) -> u64 {
+        bits &= mask;
+        ((bits >> col).wrapping_mul(0x0002_0408_1020_4081) >> 49) & 0xff
+    }
+
+    #[cfg(target_feature = "bmi2")]
+    fn get_diag1_bits(bits: u64, mask: u64, _row: usize, _col: usize) -> u64 {
+        bits.pext(mask)
+    }
+
+    #[cfg(not(target_feature = "bmi2"))]
+    fn get_diag1_bits(mut bits: u64, mask: u64, row: usize, col: usize) -> u64 {
+        bits &= mask;
+        let width = if row >= col {
+            bits = bits >> (8 * (row - col));
+            8 - (row - col)
+        } else {
+            bits = bits >> (col - row);
+            8 - (col - row)
+        };
+        (bits.wrapping_mul(0x0101_0101_0101_0101) >> 56) & ((1 << width) - 1)
+    }
+
+    #[cfg(target_feature = "bmi2")]
+    fn get_diag2_bits(bits: u64, mask: u64, _row: usize, _col: usize) -> u64 {
+        bits.pext(mask)
+    }
+
+    #[cfg(not(target_feature = "bmi2"))]
+    fn get_diag2_bits(mut bits: u64, mask: u64, row: usize, col: usize) -> u64 {
+        bits &= mask;
+        let width = if row + col >= 7 {
+            bits = bits >> (8 * (row + col - 7));
+            15 - (row + col)
+        } else {
+            bits = bits << (7 - row - col);
+            row + col + 1
+        };
+        bits |= (bits >> 56) << 63;
+        bits = bits.wrapping_mul(0x7f) & 0x8080_8080_8080_8080;
+        (bits.wrapping_mul(0x0002_0408_1020_4081) >> 56) & ((1 << width) - 1)
+    }
+
     fn solve_last_impl(&self, board: Board) -> (i8, usize) {
-        fn get_col_bits(bits: u64, col: usize) -> u64 {
-            ((bits >> col).wrapping_mul(0x0002_0408_1020_4081) >> 49) & 0xff
-        }
-
-        fn get_diag1_bits(mut bits: u64, row: usize, col: usize) -> u64 {
-            let width = if row >= col {
-                bits = bits >> (8 * (row - col));
-                8 - (row - col)
-            } else {
-                bits = bits >> (col - row);
-                8 - (col - row)
-            };
-            (bits.wrapping_mul(0x0101_0101_0101_0101) >> 56) & ((1 << width) - 1)
-        }
-
-        fn get_diag2_bits(mut bits: u64, row: usize, col: usize) -> u64 {
-            let width = if row + col >= 7 {
-                bits = bits >> (8 * (row + col - 7));
-                15 - (row + col)
-            } else {
-                bits = bits << (7 - row - col);
-                row + col + 1
-            };
-            bits |= (bits >> 56) << 63;
-            bits = bits.wrapping_mul(0x7f) & 0x8080_8080_8080_8080;
-            (bits.wrapping_mul(0x0002_0408_1020_4081) >> 56) & ((1 << width) - 1)
-        }
-
         unsafe {
             let pos = board.empty().trailing_zeros() as usize;
             let row = pos >> 3;
@@ -147,13 +121,13 @@ impl LastCache {
             let &(col_mask, diag1_mask, diag2_mask) = self.masks.get_unchecked(pos);
             let &(diag1_idx, diag2_idx) = self.indices.get_unchecked(pos);
             let &row_score = self.table.get_unchecked((row_bits as usize) * 8 + col);
-            let col_bits = Self::get_col_bits(board.player & col_mask, col);
+            let col_bits = Self::get_col_bits(board.player, col_mask, col);
             let &col_score = self.table.get_unchecked((col_bits as usize) * 8 + row);
-            let diag1_bits = Self::get_diag1_bits(board.player & diag1_mask, row, col);
+            let diag1_bits = Self::get_diag1_bits(board.player, diag1_mask, row, col);
             let &diag1_score = self
                 .table
                 .get_unchecked((diag1_bits as usize) * 8 + diag1_idx as usize);
-            let diag2_bits = Self::get_diag2_bits(board.player & diag2_mask, row, col);
+            let diag2_bits = Self::get_diag2_bits(board.player, diag2_mask, row, col);
             let &diag2_score = self
                 .table
                 .get_unchecked((diag2_bits as usize) * 8 + diag2_idx as usize);

--- a/src/engine/last_cache/test.rs
+++ b/src/engine/last_cache/test.rs
@@ -3,7 +3,7 @@ use super::*;
 use rand::{Rng, SeedableRng};
 
 fn solve_last_naive(board: Board) -> (i8, usize) {
-    let pos = unsafe { _tzcnt_u64(board.empty()) } as usize;
+    let pos = board.empty().trailing_zeros() as usize;
     match board.play(pos) {
         Some(next) => (-next.score(), 1),
         None => match board.pass_unchecked().play(pos) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 #![feature(const_option)]
+#![feature(portable_simd)]
 #![feature(test)]
 mod book;
 mod engine;

--- a/src/train.rs
+++ b/src/train.rs
@@ -265,8 +265,8 @@ impl WeightedPattern {
     fn generate_indices_impl(&self, board: &Board) -> Vec<u32> {
         let mut indices = Vec::new();
         for (idx, pattern) in self.patterns.iter().enumerate() {
-            let pbit = pext(board.player, *pattern) as usize;
-            let obit = pext(board.opponent, *pattern) as usize;
+            let pbit = board.player.pext(*pattern) as usize;
+            let obit = board.opponent.pext(*pattern) as usize;
             let pattern_index = self.base3_converter.to_base3(pbit, obit) + self.pattern_starts[idx];
             indices.push(pattern_index as u32);
         }


### PR DESCRIPTION
x86のintrinsicを直接触る代わりに、portable simd等を利用する。
これによりアーキテクチャに依存せずに動くようになる。
ただし、アーキテクチャ固有の最適化がある部分は残す。