### PR TITLE
Refine search params

### DIFF
--- a/src/book.rs
+++ b/src/book.rs
@@ -239,7 +239,7 @@ fn play_with_book(
 fn grow_book(in_book_path: &Path, out_book_path: &Path, repeat: usize) -> Result<()> {
     let book = Arc::new(Mutex::new(Book::import(in_book_path)?));
     let mut solve_obj = setup_default();
-    solve_obj.params.ybwc_empties_limit = 64;
+    solve_obj.params.parallel_empties_limit = 64;
     let sub_solver = Arc::new(SubSolver::new(&[]));
     (0..repeat).into_par_iter().for_each(|i| {
         let mut rng = SmallRng::seed_from_u64(0xbeefbeef + i as u64);

--- a/src/engine/midgame.rs
+++ b/src/engine/midgame.rs
@@ -97,7 +97,7 @@ fn simplified_abdada_intro(
     depth: i8,
 ) -> Option<(i8, Option<Hand>)> {
     let rem = popcnt(board.empty());
-    if depth >= ctx.solve_obj.params.ybwc_depth_limit || rem < ctx.solve_obj.params.ybwc_empties_limit {
+    if depth >= ctx.solve_obj.params.parallel_depth_limit || rem < ctx.solve_obj.params.parallel_empties_limit {
         let (res, stat) = solve_inner(&mut ctx.solve_obj, board, (alpha, beta), passed);
         ctx.stats.merge(stat);
         return Some((res, None));

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -36,10 +36,8 @@ pub struct SolveResponse {
 #[derive(Clone)]
 pub struct SearchParams {
     pub reduce: bool,
-    pub ybwc_depth_limit: i8,
-    pub ybwc_elder_add: i8,
-    pub ybwc_younger_add: i8,
-    pub ybwc_empties_limit: i8,
+    pub parallel_depth_limit: i8,
+    pub parallel_empties_limit: i8,
     pub eval_ordering_limit: i8,
     pub res_cache_limit: i8,
     pub stability_cut_limit: i8,

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -41,10 +41,10 @@ async fn worker_body() {
         parallel_depth_limit: 12,
         parallel_empties_limit: 16,
         eval_ordering_limit: 15,
-        res_cache_limit: 11,
+        res_cache_limit: 12,
         stability_cut_limit: 8,
         ffs_ordering_limit: 6,
-        static_ordering_limit: 3,
+        static_ordering_limit: 5,
     };
     let evaluator = Arc::new(Evaluator::new("table-220710"));
     let res_cache = Arc::new(ResCacheTable::new(256, 65536));

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -38,10 +38,8 @@ async fn shutdown_signal() {
 async fn worker_body() {
     let search_params = SearchParams {
         reduce: false,
-        ybwc_depth_limit: 12,
-        ybwc_elder_add: 1,
-        ybwc_younger_add: 2,
-        ybwc_empties_limit: 16,
+        parallel_depth_limit: 12,
+        parallel_empties_limit: 16,
         eval_ordering_limit: 15,
         res_cache_limit: 11,
         stability_cut_limit: 8,

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -9,10 +9,8 @@ pub fn setup_default() -> SolveObj {
     let evaluator = Arc::new(Evaluator::new("table-220710"));
     let search_params = SearchParams {
         reduce: false,
-        ybwc_depth_limit: 12,
-        ybwc_elder_add: 1,
-        ybwc_younger_add: 2,
-        ybwc_empties_limit: 16,
+        parallel_depth_limit: 12,
+        parallel_empties_limit: 16,
         eval_ordering_limit: 15,
         res_cache_limit: 12,
         stability_cut_limit: 8,


### PR DESCRIPTION
並列アルゴリズムをYBWCからABDADAに変更したにもかかわらずパラメータの名前を変えていなかった。
`ybwc_elder_add` , `ybwc_younger_add` は今は使っていないので削除する。