### PR TITLE
Slow pext cfg

### DIFF
--- a/src/engine/bits.rs
+++ b/src/engine/bits.rs
@@ -7,12 +7,12 @@ pub trait BitManip {
 }
 
 impl BitManip for u64 {
-    #[cfg(target_feature = "bmi2")]
+    #[cfg(all(target_feature = "bmi2", not(slow_pext)))]
     fn pext(&self, mask: u64) -> u64 {
         unsafe { _pext_u64(*self, mask) }
     }
 
-    #[cfg(not(target_feature = "bmi2"))]
+    #[cfg(not(all(target_feature = "bmi2", not(slow_pext))))]
     fn pext(&self, mut mask: u64) -> u64 {
         let mut x = *self;
         x = x & mask;

--- a/src/engine/bits.rs
+++ b/src/engine/bits.rs
@@ -7,12 +7,12 @@ pub trait BitManip {
 }
 
 impl BitManip for u64 {
-    #[cfg(target_feature = "avx2")]
+    #[cfg(target_feature = "bmi2")]
     fn pext(&self, mask: u64) -> u64 {
         unsafe { _pext_u64(*self, mask) }
     }
 
-    #[cfg(not(target_feature = "avx2"))]
+    #[cfg(not(target_feature = "bmi2"))]
     fn pext(&self, mut mask: u64) -> u64 {
         let mut x = *self;
         x = x & mask;
@@ -33,7 +33,7 @@ impl BitManip for u64 {
         x
     }
 
-    #[cfg(target_feature = "bmi1")]
+    #[cfg(target_feature = "bmi2")]
     fn pdep(&self, mask: u64) -> u64 {
         unsafe { _pdep_u64(*self, mask) }
     }

--- a/src/engine/last_cache.rs
+++ b/src/engine/last_cache.rs
@@ -63,23 +63,23 @@ impl LastCache {
         }
     }
 
-    #[cfg(target_feature = "bmi2")]
+    #[cfg(all(target_feature = "bmi2", not(slow_pext)))]
     fn get_col_bits(bits: u64, mask: u64, _col: usize) -> u64 {
         bits.pext(mask)
     }
 
-    #[cfg(not(target_feature = "bmi2"))]
+    #[cfg(not(all(target_feature = "bmi2", not(slow_pext))))]
     fn get_col_bits(mut bits: u64, mask: u64, col: usize) -> u64 {
         bits &= mask;
         ((bits >> col).wrapping_mul(0x0002_0408_1020_4081) >> 49) & 0xff
     }
 
-    #[cfg(target_feature = "bmi2")]
+    #[cfg(all(target_feature = "bmi2", not(slow_pext)))]
     fn get_diag1_bits(bits: u64, mask: u64, _row: usize, _col: usize) -> u64 {
         bits.pext(mask)
     }
 
-    #[cfg(not(target_feature = "bmi2"))]
+    #[cfg(not(all(target_feature = "bmi2", not(slow_pext))))]
     fn get_diag1_bits(mut bits: u64, mask: u64, row: usize, col: usize) -> u64 {
         bits &= mask;
         let width = if row >= col {
@@ -92,12 +92,12 @@ impl LastCache {
         (bits.wrapping_mul(0x0101_0101_0101_0101) >> 56) & ((1 << width) - 1)
     }
 
-    #[cfg(target_feature = "bmi2")]
+    #[cfg(all(target_feature = "bmi2", not(slow_pext)))]
     fn get_diag2_bits(bits: u64, mask: u64, _row: usize, _col: usize) -> u64 {
         bits.pext(mask)
     }
 
-    #[cfg(not(target_feature = "bmi2"))]
+    #[cfg(not(all(target_feature = "bmi2", not(slow_pext))))]
     fn get_diag2_bits(mut bits: u64, mask: u64, row: usize, col: usize) -> u64 {
         bits &= mask;
         let width = if row + col >= 7 {


### PR DESCRIPTION
`pext` `pdep` が存在するが非常に遅い環境向けに`--cfg=slow_pext`をrustcに与えることで、pextの代わりにソフトウェア実装を使わせられるようにする。